### PR TITLE
Add AI service abstraction

### DIFF
--- a/backend/src/services/ai/elevenlabs.ts
+++ b/backend/src/services/ai/elevenlabs.ts
@@ -1,0 +1,177 @@
+import { ElevenLabs } from 'elevenlabs';
+import { ITTSService, TTSResponse, Voice } from './interfaces';
+import { logger } from '../../utils/logger';
+import { AppError } from '../../errors/types';
+
+interface ElevenLabsConfig {
+  apiKey: string;
+  options?: {
+    maxRetries?: number;
+    retryDelay?: number;
+    timeout?: number;
+  };
+}
+
+export class ElevenLabsService implements ITTSService {
+  private client: ElevenLabs;
+  private maxRetries: number;
+  private retryDelay: number;
+  private timeout: number;
+
+  constructor(config: ElevenLabsConfig) {
+    this.client = new ElevenLabs({
+      apiKey: config.apiKey
+    });
+
+    this.maxRetries = config.options?.maxRetries || 3;
+    this.retryDelay = config.options?.retryDelay || 1000;
+    this.timeout = config.options?.timeout || 30000;
+  }
+
+  async init(): Promise<void> {
+    try {
+      // Verify API key and service availability
+      await this.getVoices();
+      logger.info('ElevenLabs service initialized');
+    } catch (error) {
+      logger.error('Failed to initialize ElevenLabs service', error);
+      throw error;
+    }
+  }
+
+  async dispose(): Promise<void> {
+    // No cleanup needed
+  }
+
+  async textToSpeech(
+    text: string,
+    options?: {
+      voiceId?: string;
+      speed?: number;
+      pitch?: number;
+      volume?: number;
+      format?: 'mp3' | 'wav' | 'ogg';
+      quality?: 'low' | 'medium' | 'high';
+    }
+  ): Promise<TTSResponse> {
+    try {
+      let attempts = 0;
+      let lastError: Error | undefined;
+
+      while (attempts < this.maxRetries) {
+        try {
+          const response = await Promise.race([
+            this.client.textToSpeech({
+              text,
+              voice_id: options?.voiceId,
+              voice_settings: {
+                stability: 0.5,
+                similarity_boost: 0.75,
+                style: 0.5,
+                use_speaker_boost: true
+              },
+              model_id: options?.quality === 'high' ? 'eleven_multilingual_v2' : 'eleven_monolingual_v1',
+              output_format: options?.format || 'mp3'
+            }),
+            new Promise((_, reject) =>
+              setTimeout(
+                () => reject(new Error('Request timed out')),
+                this.timeout
+              )
+            )
+          ]);
+
+          // Get audio duration
+          const audioContext = new AudioContext();
+          const audioBuffer = await audioContext.decodeAudioData(response.arrayBuffer());
+          const duration = audioBuffer.duration;
+
+          return {
+            audio: Buffer.from(response),
+            duration,
+            metadata: {
+              format: options?.format || 'mp3',
+              quality: options?.quality || 'medium',
+              voiceId: options?.voiceId
+            }
+          };
+        } catch (error) {
+          lastError = error instanceof Error ? error : new Error(String(error));
+          attempts++;
+
+          if (attempts < this.maxRetries) {
+            logger.warn('Retrying ElevenLabs request', {
+              attempt: attempts,
+              error: lastError.message
+            });
+            await new Promise(resolve =>
+              setTimeout(resolve, this.retryDelay * attempts)
+            );
+          }
+        }
+      }
+
+      throw lastError || new Error('Failed to generate speech');
+    } catch (error) {
+      logger.error('ElevenLabs text to speech error', { error, text });
+      throw AppError.aiError('Failed to generate speech', error);
+    }
+  }
+
+  async getVoices(): Promise<Voice[]> {
+    try {
+      const response = await this.client.getVoices();
+
+      return response.voices.map(voice => ({
+        id: voice.voice_id,
+        name: voice.name,
+        gender: voice.labels?.gender || 'unknown',
+        language: voice.labels?.language || 'en',
+        preview_url: voice.preview_url
+      }));
+    } catch (error) {
+      logger.error('ElevenLabs get voices error', { error });
+      throw AppError.aiError('Failed to get voices', error);
+    }
+  }
+
+  async getVoice(voiceId: string): Promise<Voice> {
+    try {
+      const response = await this.client.getVoice(voiceId);
+
+      return {
+        id: response.voice_id,
+        name: response.name,
+        gender: response.labels?.gender || 'unknown',
+        language: response.labels?.language || 'en',
+        preview_url: response.preview_url
+      };
+    } catch (error) {
+      logger.error('ElevenLabs get voice error', { error, voiceId });
+      throw AppError.aiError('Failed to get voice', error);
+    }
+  }
+
+  async getVoicePreview(voiceId: string, text?: string): Promise<Buffer> {
+    try {
+      if (text) {
+        const response = await this.textToSpeech(text, {
+          voiceId,
+          quality: 'low'
+        });
+        return response.audio;
+      } else {
+        const voice = await this.getVoice(voiceId);
+        if (!voice.preview_url) {
+          throw new Error('Voice has no preview URL');
+        }
+
+        const response = await fetch(voice.preview_url);
+        return Buffer.from(await response.arrayBuffer());
+      }
+    } catch (error) {
+      logger.error('ElevenLabs get voice preview error', { error, voiceId });
+      throw AppError.aiError('Failed to get voice preview', error);
+    }
+  }
+}

--- a/backend/src/services/ai/factory.ts
+++ b/backend/src/services/ai/factory.ts
@@ -1,0 +1,155 @@
+import { IAIServiceFactory, ILLMService, ITTSService } from './interfaces';
+import { GroqService } from './groq';
+import { ElevenLabsService } from './elevenlabs';
+import { logger } from '../../utils/logger';
+import { AppError } from '../../errors/types';
+
+export class AIServiceFactory implements IAIServiceFactory {
+  private static instance: AIServiceFactory;
+  private llmServices: Map<string, ILLMService>;
+  private ttsServices: Map<string, ITTSService>;
+
+  private constructor() {
+    this.llmServices = new Map();
+    this.ttsServices = new Map();
+  }
+
+  static getInstance(): AIServiceFactory {
+    if (!AIServiceFactory.instance) {
+      AIServiceFactory.instance = new AIServiceFactory();
+    }
+    return AIServiceFactory.instance;
+  }
+
+  async createLLMService(config: {
+    provider: string;
+    apiKey: string;
+    model?: string;
+    options?: Record<string, any>;
+  }): Promise<ILLMService> {
+    try {
+      const serviceKey = `${config.provider}:${config.model || 'default'}`;
+
+      // Return existing service if available
+      if (this.llmServices.has(serviceKey)) {
+        return this.llmServices.get(serviceKey)!;
+      }
+
+      // Create new service based on provider
+      let service: ILLMService;
+      switch (config.provider.toLowerCase()) {
+        case 'groq':
+          service = new GroqService({
+            apiKey: config.apiKey,
+            model: config.model,
+            options: config.options
+          });
+          break;
+        // Add more providers here
+        default:
+          throw new Error(`Unsupported LLM provider: ${config.provider}`);
+      }
+
+      // Initialize service
+      await service.init();
+
+      // Cache service instance
+      this.llmServices.set(serviceKey, service);
+
+      return service;
+    } catch (error) {
+      logger.error('Failed to create LLM service', {
+        error,
+        provider: config.provider
+      });
+      throw AppError.aiError('Failed to create LLM service', error);
+    }
+  }
+
+  async createTTSService(config: {
+    provider: string;
+    apiKey: string;
+    options?: Record<string, any>;
+  }): Promise<ITTSService> {
+    try {
+      const serviceKey = config.provider;
+
+      // Return existing service if available
+      if (this.ttsServices.has(serviceKey)) {
+        return this.ttsServices.get(serviceKey)!;
+      }
+
+      // Create new service based on provider
+      let service: ITTSService;
+      switch (config.provider.toLowerCase()) {
+        case 'elevenlabs':
+          service = new ElevenLabsService({
+            apiKey: config.apiKey,
+            options: config.options
+          });
+          break;
+        // Add more providers here
+        default:
+          throw new Error(`Unsupported TTS provider: ${config.provider}`);
+      }
+
+      // Initialize service
+      await service.init();
+
+      // Cache service instance
+      this.ttsServices.set(serviceKey, service);
+
+      return service;
+    } catch (error) {
+      logger.error('Failed to create TTS service', {
+        error,
+        provider: config.provider
+      });
+      throw AppError.aiError('Failed to create TTS service', error);
+    }
+  }
+
+  /**
+   * Get all available LLM services
+   */
+  getLLMServices(): Map<string, ILLMService> {
+    return new Map(this.llmServices);
+  }
+
+  /**
+   * Get all available TTS services
+   */
+  getTTSServices(): Map<string, ITTSService> {
+    return new Map(this.ttsServices);
+  }
+
+  /**
+   * Dispose all services
+   */
+  async dispose(): Promise<void> {
+    try {
+      // Dispose LLM services
+      for (const [key, service] of this.llmServices) {
+        try {
+          await service.dispose();
+          this.llmServices.delete(key);
+        } catch (error) {
+          logger.error('Error disposing LLM service', { error, key });
+        }
+      }
+
+      // Dispose TTS services
+      for (const [key, service] of this.ttsServices) {
+        try {
+          await service.dispose();
+          this.ttsServices.delete(key);
+        } catch (error) {
+          logger.error('Error disposing TTS service', { error, key });
+        }
+      }
+    } catch (error) {
+      logger.error('Error disposing AI services', { error });
+      throw AppError.aiError('Failed to dispose AI services', error);
+    }
+  }
+}

--- a/backend/src/services/ai/groq.ts
+++ b/backend/src/services/ai/groq.ts
@@ -1,0 +1,167 @@
+import { Groq } from 'groq-sdk';
+import { ILLMService, AIMessage, AIResponse } from './interfaces';
+import { logger } from '../../utils/logger';
+import { AppError } from '../../errors/types';
+
+interface GroqConfig {
+  apiKey: string;
+  model?: string;
+  options?: {
+    maxRetries?: number;
+    retryDelay?: number;
+    timeout?: number;
+  };
+}
+
+export class GroqService implements ILLMService {
+  private client: Groq;
+  private model: string;
+  private maxRetries: number;
+  private retryDelay: number;
+  private timeout: number;
+
+  constructor(config: GroqConfig) {
+    this.client = new Groq({
+      apiKey: config.apiKey
+    });
+
+    this.model = config.model || 'mixtral-8x7b-32768';
+    this.maxRetries = config.options?.maxRetries || 3;
+    this.retryDelay = config.options?.retryDelay || 1000;
+    this.timeout = config.options?.timeout || 30000;
+  }
+
+  async init(): Promise<void> {
+    try {
+      // Verify API key and model availability
+      await this.getModels();
+      logger.info('Groq service initialized');
+    } catch (error) {
+      logger.error('Failed to initialize Groq service', error);
+      throw error;
+    }
+  }
+
+  async dispose(): Promise<void> {
+    // No cleanup needed
+  }
+
+  async generateResponse(
+    messages: AIMessage[],
+    options?: {
+      temperature?: number;
+      maxTokens?: number;
+      stopSequences?: string[];
+      topP?: number;
+      frequencyPenalty?: number;
+      presencePenalty?: number;
+      generateEmbedding?: boolean;
+    }
+  ): Promise<AIResponse> {
+    try {
+      let attempts = 0;
+      let lastError: Error | undefined;
+
+      while (attempts < this.maxRetries) {
+        try {
+          const completion = await Promise.race([
+            this.client.chat.completions.create({
+              messages: messages.map(msg => ({
+                role: msg.role,
+                content: msg.content
+              })),
+              model: this.model,
+              temperature: options?.temperature,
+              max_tokens: options?.maxTokens,
+              stop: options?.stopSequences,
+              top_p: options?.topP,
+              frequency_penalty: options?.frequencyPenalty,
+              presence_penalty: options?.presencePenalty
+            }),
+            new Promise((_, reject) =>
+              setTimeout(
+                () => reject(new Error('Request timed out')),
+                this.timeout
+              )
+            )
+          ]);
+
+          const response: AIResponse = {
+            message: completion.choices[0].message.content || ''
+          };
+
+          if (options?.generateEmbedding) {
+            response.embedding = await this.generateEmbedding(response.message);
+          }
+
+          return response;
+        } catch (error) {
+          lastError = error instanceof Error ? error : new Error(String(error));
+          attempts++;
+
+          if (attempts < this.maxRetries) {
+            logger.warn('Retrying Groq request', {
+              attempt: attempts,
+              error: lastError.message
+            });
+            await new Promise(resolve =>
+              setTimeout(resolve, this.retryDelay * attempts)
+            );
+          }
+        }
+      }
+
+      throw lastError || new Error('Failed to generate response');
+    } catch (error) {
+      logger.error('Groq generate response error', { error, messages });
+      throw AppError.aiError('Failed to generate response', error);
+    }
+  }
+
+  async generateEmbedding(text: string): Promise<number[]> {
+    try {
+      const response = await this.client.embeddings.create({
+        model: 'llama2-70b-4096',
+        input: text
+      });
+
+      return response.data[0].embedding;
+    } catch (error) {
+      logger.error('Groq generate embedding error', { error, text });
+      throw AppError.aiError('Failed to generate embedding', error);
+    }
+  }
+
+  async getModels(): Promise<string[]> {
+    try {
+      const response = await this.client.models.list();
+      return response.data.map(model => model.id);
+    } catch (error) {
+      logger.error('Groq get models error', { error });
+      throw AppError.aiError('Failed to get models', error);
+    }
+  }
+
+  async getModelInfo(model: string): Promise<{
+    name: string;
+    description: string;
+    maxTokens: number;
+    trainingData: string;
+    capabilities: string[];
+  }> {
+    try {
+      const response = await this.client.models.retrieve(model);
+
+      return {
+        name: response.id,
+        description: response.description || '',
+        maxTokens: response.context_window || 0,
+        trainingData: response.training_data || '',
+        capabilities: response.capabilities || []
+      };
+    } catch (error) {
+      logger.error('Groq get model info error', { error, model });
+      throw AppError.aiError('Failed to get model info', error);
+    }
+  }
+}

--- a/backend/src/services/ai/index.ts
+++ b/backend/src/services/ai/index.ts
@@ -1,0 +1,5 @@
+export * from './interfaces';
+export * from './groq';
+export * from './elevenlabs';
+export * from './factory';
+export * from './provider';

--- a/backend/src/services/ai/interfaces.ts
+++ b/backend/src/services/ai/interfaces.ts
@@ -1,0 +1,122 @@
+import { IService } from '../base';
+
+// Common types
+export interface AIMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface AIResponse {
+  message: string;
+  embedding?: number[];
+  metadata?: Record<string, any>;
+}
+
+export interface TTSResponse {
+  audio: Buffer;
+  duration: number;
+  metadata?: Record<string, any>;
+}
+
+export interface Voice {
+  id: string;
+  name: string;
+  gender: string;
+  language: string;
+  preview_url?: string;
+}
+
+// LLM service interface
+export interface ILLMService extends IService {
+  /**
+   * Generate a response from the LLM
+   */
+  generateResponse(
+    messages: AIMessage[],
+    options?: {
+      temperature?: number;
+      maxTokens?: number;
+      stopSequences?: string[];
+      topP?: number;
+      frequencyPenalty?: number;
+      presencePenalty?: number;
+      generateEmbedding?: boolean;
+    }
+  ): Promise<AIResponse>;
+
+  /**
+   * Generate embeddings for text
+   */
+  generateEmbedding(text: string): Promise<number[]>;
+
+  /**
+   * Get available models
+   */
+  getModels(): Promise<string[]>;
+
+  /**
+   * Get model info
+   */
+  getModelInfo(model: string): Promise<{
+    name: string;
+    description: string;
+    maxTokens: number;
+    trainingData: string;
+    capabilities: string[];
+  }>;
+}
+
+// TTS service interface
+export interface ITTSService extends IService {
+  /**
+   * Convert text to speech
+   */
+  textToSpeech(
+    text: string,
+    options?: {
+      voiceId?: string;
+      speed?: number;
+      pitch?: number;
+      volume?: number;
+      format?: 'mp3' | 'wav' | 'ogg';
+      quality?: 'low' | 'medium' | 'high';
+    }
+  ): Promise<TTSResponse>;
+
+  /**
+   * Get available voices
+   */
+  getVoices(): Promise<Voice[]>;
+
+  /**
+   * Get voice by ID
+   */
+  getVoice(voiceId: string): Promise<Voice>;
+
+  /**
+   * Get voice preview
+   */
+  getVoicePreview(voiceId: string, text?: string): Promise<Buffer>;
+}
+
+// AI service factory interface
+export interface IAIServiceFactory {
+  /**
+   * Create LLM service instance
+   */
+  createLLMService(config: {
+    provider: string;
+    apiKey: string;
+    model?: string;
+    options?: Record<string, any>;
+  }): Promise<ILLMService>;
+
+  /**
+   * Create TTS service instance
+   */
+  createTTSService(config: {
+    provider: string;
+    apiKey: string;
+    options?: Record<string, any>;
+  }): Promise<ITTSService>;
+}

--- a/backend/src/services/ai/provider.ts
+++ b/backend/src/services/ai/provider.ts
@@ -1,0 +1,208 @@
+import { IService } from '../base';
+import { ILLMService, ITTSService, AIMessage, AIResponse, TTSResponse } from './interfaces';
+import { AIServiceFactory } from './factory';
+import { logger } from '../../utils/logger';
+import { AppError } from '../../errors/types';
+
+interface AIProviderConfig {
+  llm: {
+    provider: string;
+    apiKey: string;
+    model?: string;
+    options?: Record<string, any>;
+  };
+  tts: {
+    provider: string;
+    apiKey: string;
+    options?: Record<string, any>;
+  };
+}
+
+/**
+ * AI service provider that manages LLM and TTS services
+ */
+export class AIProvider implements IService {
+  private factory: AIServiceFactory;
+  private llmService?: ILLMService;
+  private ttsService?: ITTSService;
+  private config: AIProviderConfig;
+
+  constructor(config: AIProviderConfig) {
+    this.factory = AIServiceFactory.getInstance();
+    this.config = config;
+  }
+
+  async init(): Promise<void> {
+    try {
+      // Initialize LLM service
+      this.llmService = await this.factory.createLLMService(this.config.llm);
+
+      // Initialize TTS service
+      this.ttsService = await this.factory.createTTSService(this.config.tts);
+
+      logger.info('AI provider initialized');
+    } catch (error) {
+      logger.error('Failed to initialize AI provider', error);
+      throw error;
+    }
+  }
+
+  async dispose(): Promise<void> {
+    await this.factory.dispose();
+  }
+
+  /**
+   * Generate response from LLM
+   */
+  async generateResponse(
+    messages: AIMessage[],
+    options?: {
+      temperature?: number;
+      maxTokens?: number;
+      stopSequences?: string[];
+      topP?: number;
+      frequencyPenalty?: number;
+      presencePenalty?: number;
+      generateEmbedding?: boolean;
+    }
+  ): Promise<AIResponse> {
+    try {
+      if (!this.llmService) {
+        throw new Error('LLM service not initialized');
+      }
+
+      return await this.llmService.generateResponse(messages, options);
+    } catch (error) {
+      logger.error('AI provider generate response error', { error, messages });
+      throw AppError.aiError('Failed to generate response', error);
+    }
+  }
+
+  /**
+   * Generate embeddings for text
+   */
+  async generateEmbedding(text: string): Promise<number[]> {
+    try {
+      if (!this.llmService) {
+        throw new Error('LLM service not initialized');
+      }
+
+      return await this.llmService.generateEmbedding(text);
+    } catch (error) {
+      logger.error('AI provider generate embedding error', { error, text });
+      throw AppError.aiError('Failed to generate embedding', error);
+    }
+  }
+
+  /**
+   * Convert text to speech
+   */
+  async textToSpeech(
+    text: string,
+    options?: {
+      voiceId?: string;
+      speed?: number;
+      pitch?: number;
+      volume?: number;
+      format?: 'mp3' | 'wav' | 'ogg';
+      quality?: 'low' | 'medium' | 'high';
+    }
+  ): Promise<TTSResponse> {
+    try {
+      if (!this.ttsService) {
+        throw new Error('TTS service not initialized');
+      }
+
+      return await this.ttsService.textToSpeech(text, options);
+    } catch (error) {
+      logger.error('AI provider text to speech error', { error, text });
+      throw AppError.aiError('Failed to generate speech', error);
+    }
+  }
+
+  /**
+   * Get available voices
+   */
+  async getVoices(): Promise<Voice[]> {
+    try {
+      if (!this.ttsService) {
+        throw new Error('TTS service not initialized');
+      }
+
+      return await this.ttsService.getVoices();
+    } catch (error) {
+      logger.error('AI provider get voices error', { error });
+      throw AppError.aiError('Failed to get voices', error);
+    }
+  }
+
+  /**
+   * Get voice by ID
+   */
+  async getVoice(voiceId: string): Promise<Voice> {
+    try {
+      if (!this.ttsService) {
+        throw new Error('TTS service not initialized');
+      }
+
+      return await this.ttsService.getVoice(voiceId);
+    } catch (error) {
+      logger.error('AI provider get voice error', { error, voiceId });
+      throw AppError.aiError('Failed to get voice', error);
+    }
+  }
+
+  /**
+   * Get voice preview
+   */
+  async getVoicePreview(voiceId: string, text?: string): Promise<Buffer> {
+    try {
+      if (!this.ttsService) {
+        throw new Error('TTS service not initialized');
+      }
+
+      return await this.ttsService.getVoicePreview(voiceId, text);
+    } catch (error) {
+      logger.error('AI provider get voice preview error', { error, voiceId });
+      throw AppError.aiError('Failed to get voice preview', error);
+    }
+  }
+
+  /**
+   * Get LLM models
+   */
+  async getModels(): Promise<string[]> {
+    try {
+      if (!this.llmService) {
+        throw new Error('LLM service not initialized');
+      }
+
+      return await this.llmService.getModels();
+    } catch (error) {
+      logger.error('AI provider get models error', { error });
+      throw AppError.aiError('Failed to get models', error);
+    }
+  }
+
+  /**
+   * Get model info
+   */
+  async getModelInfo(model: string): Promise<{
+    name: string;
+    description: string;
+    maxTokens: number;
+    trainingData: string;
+    capabilities: string[];
+  }> {
+    try {
+      if (!this.llmService) {
+        throw new Error('LLM service not initialized');
+      }
+
+      return await this.llmService.getModelInfo(model);
+    } catch (error) {
+      logger.error('AI provider get model info error', { error, model });
+      throw AppError.aiError('Failed to get model info', error);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds AI service abstraction:

- Add interfaces for LLM and TTS services
- Add Groq LLM service implementation
- Add ElevenLabs TTS service implementation
- Add AI service factory
- Add AI service provider

The PR aims to improve AI services by:
- Providing a clean interface for AI services
- Abstracting provider-specific implementations
- Making it easy to switch providers
- Providing a unified error handling
- Adding retry and timeout support